### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -98,6 +98,8 @@ jobs:
         run: pytest -q
 
   security-audit:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/knoksen/knoksPix/security/code-scanning/11](https://github.com/knoksen/knoksPix/security/code-scanning/11)

To address this problem, add an explicit `permissions` block with minimal privileges to the `security-audit` job. In this case, the only requirement is to check out code and upload an artifact, both of which work with `contents: read`. This change should be made in the `.github/workflows/ci-cd.yml` file, specifically under the `security-audit:` job definition (line 100-101, before `runs-on:`). No other code or configuration changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
